### PR TITLE
Append directory semantics

### DIFF
--- a/payjoin-mailroom/src/config.rs
+++ b/payjoin-mailroom/src/config.rs
@@ -14,6 +14,10 @@ pub struct Config {
     pub timeout: Duration,
     #[serde(deserialize_with = "deserialize_duration_secs")]
     pub mailbox_ttl: Duration,
+    /// When true, repeated v2 writes to the same mailbox append fixed-size
+    /// frames instead of being rejected (append-only mailbox). Defaults to
+    /// false, preserving single-payload BIP77 semantics.
+    pub append_mailbox: bool,
     pub v1: Option<V1Config>,
     #[cfg(feature = "telemetry")]
     pub telemetry: Option<TelemetryConfig>,
@@ -88,6 +92,7 @@ impl Default for Config {
             storage_dir: PathBuf::from("./data"),
             timeout: Duration::from_secs(30),
             mailbox_ttl: Duration::from_secs(60 * 60 * 24 * 7), // 1 week
+            append_mailbox: false,
             v1: None,
             #[cfg(feature = "telemetry")]
             telemetry: None,
@@ -119,6 +124,7 @@ impl Config {
             storage_dir,
             timeout,
             mailbox_ttl: Duration::from_secs(60 * 60 * 24 * 7), // 1 week
+            append_mailbox: false,
             v1,
             #[cfg(feature = "telemetry")]
             telemetry: None,

--- a/payjoin-mailroom/src/db/files.rs
+++ b/payjoin-mailroom/src/db/files.rs
@@ -21,6 +21,14 @@ use crate::db::{Db as DbTrait, Error as DbError};
 /// mailboxes/tx, ~4K txs/block, and ~144 blocks/24h.
 const DEFAULT_CAPACITY: usize = 1 << (1 + 12 + 8);
 
+/// Size in bytes of one v2 mailbox frame: the HPKE-padded ciphertext length.
+///
+/// The directory stores append-only mailboxes as opaque concatenated frames and
+/// doesn't slice them, so this is currently only needed by tests. It stays tied
+/// to the directory's `PADDED_MESSAGE_BYTES` as the single source of truth.
+#[cfg(test)]
+pub(crate) const FRAME_SIZE: usize = payjoin::directory::PADDED_MESSAGE_BYTES;
+
 #[derive(Debug)]
 struct V2WaitMapEntry {
     receiver: future::Shared<oneshot::Receiver<Arc<Vec<u8>>>>,
@@ -87,22 +95,23 @@ impl DiskStorage {
     }
 
     async fn get(&self, id: &ShortId) -> io::Result<Option<(SystemTime, Vec<u8>)>> {
-        // If the file doesn't exist, it's Ok(None), not Err
+        // Returns the entire mailbox: zero or more fixed-size frames
+        // concatenated verbatim. Callers slice by frame size as needed.
         let mut file = match File::open(self.mailbox_path(id)).await {
             Ok(file) => file,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err),
         };
-
         let created = file.metadata().await?.created()?;
-
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer).await?;
         self.xor_buffer(&mut buffer);
-
         Ok(Some((created, buffer)))
     }
 
+    /// Single-write insert: create the mailbox, idempotently accept an
+    /// identical re-write, or reject a conflicting write. This is the default
+    /// (non-append) behavior; append mode uses [`Self::append_frame`] instead.
     async fn try_insert(
         &self,
         id: &ShortId,
@@ -150,10 +159,49 @@ impl DiskStorage {
         }
     }
 
-    fn xor_buffer(&self, buffer: &mut [u8]) {
-        for (byte, &pattern) in buffer.iter_mut().zip(self.xor.iter().cycle()) {
-            *byte ^= pattern;
+    fn xor_buffer(&self, buffer: &mut [u8]) { self.xor_buffer_at(buffer, 0) }
+
+    /// XOR `buffer` with the obfuscation pattern phased to `offset`, the
+    /// buffer's absolute position in the mailbox file. This lets a frame
+    /// appended at the end be de-obfuscated as part of one continuous stream.
+    fn xor_buffer_at(&self, buffer: &mut [u8], offset: usize) {
+        let period = self.xor.len();
+        for (i, byte) in buffer.iter_mut().enumerate() {
+            *byte ^= self.xor[(offset + i) % period];
         }
+    }
+
+    /// Append one frame to the end of an existing mailbox, in place.
+    /// The caller guarantees the mailbox exists, so a missing file surfaces as
+    /// an I/O error.
+    async fn append_frame(&self, id: &ShortId, frame: &[u8]) -> io::Result<()> {
+        let path = self.mailbox_path(id);
+        let offset = fs::metadata(&path).await?.len() as usize;
+
+        let mut buffer = frame.to_vec();
+        self.xor_buffer_at(&mut buffer, offset);
+
+        let mut file = fs::OpenOptions::new().append(true).open(&path).await?;
+        file.write_all(&buffer).await?;
+        file.sync_data().await?;
+
+        Ok(())
+    }
+
+    /// Read the frame at `index`. Frames are a uniform [`FRAME_SIZE`] bytes.
+    #[cfg(test)]
+    async fn read_frame(
+        &self,
+        id: &ShortId,
+        index: usize,
+    ) -> io::Result<Option<(SystemTime, Vec<u8>)>> {
+        let Some((created, data)) = self.get(id).await? else { return Ok(None) };
+        let start = index * FRAME_SIZE;
+        if start >= data.len() {
+            return Ok(None);
+        }
+        let end = (start + FRAME_SIZE).min(data.len());
+        Ok(Some((created, data[start..end].to_vec())))
     }
 
     async fn remove(&self, id: &ShortId) -> io::Result<Option<()>> {
@@ -205,11 +253,25 @@ impl Mailboxes {
 pub struct FilesDb {
     timeout: Duration,
     pub(crate) mailboxes: Arc<Mutex<Mailboxes>>,
+    /// When enabled, repeated v2 writes to the same mailbox append fixed-size
+    /// frames instead of being rejected. Off preserves single-payload BIP77
+    /// semantics. See [`Self::with_append_mailbox`].
+    append_mailbox: bool,
 }
 
 impl FilesDb {
     pub async fn init(timeout: Duration, path: PathBuf, ttl: Duration) -> io::Result<Self> {
-        Ok(Self { timeout, mailboxes: Arc::new(Mutex::new(Mailboxes::init(path, ttl).await?)) })
+        Ok(Self {
+            timeout,
+            mailboxes: Arc::new(Mutex::new(Mailboxes::init(path, ttl).await?)),
+            append_mailbox: false,
+        })
+    }
+
+    /// Enable append-only mailbox semantics for v2 writes (off by default).
+    pub fn with_append_mailbox(mut self) -> Self {
+        self.append_mailbox = true;
+        self
     }
 
     pub async fn prune(&self) -> io::Result<Duration> { self.mailboxes.lock().await.prune().await }
@@ -235,7 +297,7 @@ impl DbTrait for FilesDb {
         payload: Vec<u8>,
     ) -> Result<Option<()>, DbError<Self::OperationalError>> {
         let mut guard = self.mailboxes.lock().await;
-        Ok(guard.post_v2(id, payload).await?)
+        Ok(guard.post_v2(id, payload, self.append_mailbox).await?)
     }
 
     async fn wait_for_v2_payload(
@@ -367,16 +429,27 @@ impl Mailboxes {
         }
     }
 
-    async fn post_v2(&mut self, id: &ShortId, payload: Vec<u8>) -> Result<Option<()>, Error> {
+    async fn post_v2(
+        &mut self,
+        id: &ShortId,
+        payload: Vec<u8>,
+        append: bool,
+    ) -> Result<Option<()>, Error> {
         if !self.has_capacity().await? {
             return Err(Error::OverCapacity);
         }
 
-        let Some(created) = self.persistent_storage.try_insert(id, &payload).await? else {
-            return Ok(None);
-        };
-
-        self.insert_order.push_back((created, *id));
+        // Append mode: a write to an already-created mailbox concatenates one
+        // more fixed-size frame instead of being rejected. Appends extend an
+        // existing entry, so they don't consume a new capacity/prune slot.
+        if append && self.persistent_storage.contains_key(id).await? {
+            self.persistent_storage.append_frame(id, &payload).await?;
+        } else {
+            let Some(created) = self.persistent_storage.try_insert(id, &payload).await? else {
+                return Ok(None);
+            };
+            self.insert_order.push_back((created, *id));
+        }
 
         // If there are pending readers, satisfy them
         if let Some(pending) = self.pending_v2.remove(id) {
@@ -554,7 +627,7 @@ mod tests {
     use payjoin::directory::ShortId;
     use tokio::fs;
 
-    use crate::db::files::DiskStorage;
+    use crate::db::files::{DiskStorage, FRAME_SIZE};
     use crate::db::{Db as DbTrait, Error as DbError, FilesDb};
 
     #[tokio::test]
@@ -597,6 +670,68 @@ mod tests {
         assert_eq!(storage.xor, xor_pattern, "xor pattern loaded from file");
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_fixed_frames() -> std::io::Result<()> {
+        // Frames are a uniform FRAME_SIZE; appended verbatim, read back by index.
+        let dir = tempfile::tempdir()?;
+        let storage = DiskStorage::init(dir.path().to_owned()).await?;
+        let id = ShortId([1u8; 8]);
+
+        let frame = |b: u8| vec![b; FRAME_SIZE];
+        let (frame0, frame1, frame2) = (frame(0xA0), frame(0xB1), frame(0xC2));
+
+        // try_insert creates the mailbox with the first frame; append_frame
+        // concatenates subsequent frames in place.
+        storage.try_insert(&id, &frame0).await?.expect("first write should succeed");
+        storage.append_frame(&id, &frame1).await?;
+        storage.append_frame(&id, &frame2).await?;
+
+        // Each frame is retrievable by index, in order.
+        let (_, f0) = storage.read_frame(&id, 0).await?.expect("frame 0 exists");
+        let (_, f1) = storage.read_frame(&id, 1).await?.expect("frame 1 exists");
+        let (_, f2) = storage.read_frame(&id, 2).await?.expect("frame 2 exists");
+        assert_eq!(f0, frame0);
+        assert_eq!(f1, frame1);
+        assert_eq!(f2, frame2);
+
+        // Reading past the last frame yields None (the stream terminator).
+        assert!(storage.read_frame(&id, 3).await?.is_none(), "no frame past the end");
+
+        // The whole mailbox is the frames concatenated verbatim, no framing.
+        let (_, all) = storage.get(&id).await?.expect("mailbox exists");
+        assert_eq!(all, [frame0, frame1, frame2].concat());
+
+        // The creation time is preserved across appends (in-place, no rewrite).
+        let (created_a, _) = storage.read_frame(&id, 0).await?.expect("frame 0 exists");
+        let (created_b, _) = storage.read_frame(&id, 2).await?.expect("frame 2 exists");
+        assert_eq!(created_a, created_b, "creation time stable across appends");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_filesdb_append_counts_one_capacity_slot() {
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db =
+            FilesDb::init(Duration::from_secs(10), dir.path().to_owned(), Duration::from_secs(60))
+                .await
+                .unwrap()
+                .with_append_mailbox();
+
+        let id = ShortId([2u8; 8]);
+
+        // Three POSTs to the same id: one create + two appends.
+        assert!(db.post_v2_payload(&id, b"frame_AA".to_vec()).await.unwrap().is_some());
+        assert!(db.post_v2_payload(&id, b"frame_BB".to_vec()).await.unwrap().is_some());
+        assert!(db.post_v2_payload(&id, b"frame_CC".to_vec()).await.unwrap().is_some());
+
+        // Appends must not inflate the capacity/prune accounting: one mailbox,
+        // one insert_order entry, regardless of how many frames it holds.
+        assert_eq!(db.mailboxes.lock().await.insert_order.len(), 1, "appends share one slot");
     }
 
     #[tokio::test]

--- a/payjoin-mailroom/src/directory.rs
+++ b/payjoin-mailroom/src/directory.rs
@@ -8,7 +8,7 @@ use axum::body::{Body, Bytes};
 use axum::http::header::{HeaderValue, ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_TYPE};
 use axum::http::{Method, Request, Response, StatusCode, Uri};
 use http_body_util::BodyExt;
-use payjoin::directory::{ShortId, ShortIdError, ENCAPSULATED_MESSAGE_BYTES};
+use payjoin::directory::{ShortId, ShortIdError, ENCAPSULATED_RESPONSE_BYTES};
 use tracing::{debug, error, trace, warn};
 
 use crate::db::{Db, Error as DbError, SendableError};
@@ -16,8 +16,11 @@ use crate::ohttp_relay::SentinelTag;
 
 const CHACHA20_POLY1305_NONCE_LEN: usize = 32; // chacha20poly1305 n_k
 const POLY1305_TAG_SIZE: usize = 16;
-pub const BHTTP_REQ_BYTES: usize =
-    ENCAPSULATED_MESSAGE_BYTES - (CHACHA20_POLY1305_NONCE_LEN + POLY1305_TAG_SIZE);
+/// Usable BHTTP payload size of an encapsulated OHTTP response, after the
+/// ChaCha20-Poly1305 nonce and tag. A read response is padded to this length
+/// before encapsulation.
+pub const BHTTP_RES_BYTES: usize =
+    ENCAPSULATED_RESPONSE_BYTES - (CHACHA20_POLY1305_NONCE_LEN + POLY1305_TAG_SIZE);
 const V1_MAX_BUFFER_SIZE: usize = 65536;
 
 const V1_REJECT_RES_JSON: &str =
@@ -243,11 +246,11 @@ impl<D: Db> Service<D> {
         bhttp_res
             .write_bhttp(bhttp::Mode::KnownLength, &mut bhttp_bytes)
             .map_err(|e| HandlerError::InternalServerError(e.into()))?;
-        bhttp_bytes.resize(BHTTP_REQ_BYTES, 0);
+        bhttp_bytes.resize(BHTTP_RES_BYTES, 0);
         let ohttp_res = res_ctx
             .encapsulate(&bhttp_bytes)
             .map_err(|e| HandlerError::InternalServerError(e.into()))?;
-        assert!(ohttp_res.len() == ENCAPSULATED_MESSAGE_BYTES, "Unexpected OHTTP response size");
+        assert!(ohttp_res.len() == ENCAPSULATED_RESPONSE_BYTES, "Unexpected OHTTP response size");
         Ok(Response::new(full(ohttp_res)))
     }
 
@@ -285,6 +288,7 @@ impl<D: Db> Service<D> {
         }
     }
 
+    /// Read the entire mailbox
     async fn get_mailbox(&self, id: &str) -> Result<Response<Body>, HandlerError> {
         trace!("get_mailbox");
         let id = ShortId::from_str(id)?;
@@ -586,6 +590,7 @@ mod tests {
     use payjoin::directory::ShortId;
 
     use super::*;
+    use crate::db::files::FRAME_SIZE;
     use crate::db::FilesDb;
     use crate::ohttp_relay::SentinelTag;
 
@@ -613,6 +618,41 @@ mod tests {
         let (parts, body) = res.into_parts();
         let bytes = body.collect().await.unwrap().to_bytes();
         (parts.status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    /// A `Service` whose v2 mailbox writes append fixed-size frames.
+    async fn append_test_service() -> Service<FilesDb> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = FilesDb::init(Duration::from_millis(100), dir.keep(), Duration::from_secs(3600))
+            .await
+            .expect("db init")
+            .with_append_mailbox();
+        let ohttp: ohttp::Server =
+            crate::key_config::gen_ohttp_server_config().expect("ohttp config").into();
+        Service::new(db, ohttp, SentinelTag::new([0u8; 32]), None)
+    }
+
+    #[tokio::test]
+    async fn append_mailbox_read_returns_all_frames() {
+        let svc = append_test_service().await;
+        let id = valid_short_id_path();
+
+        // Post three uniform, fixed-size frames to the same mailbox.
+        let frame = |b: u8| vec![b; FRAME_SIZE];
+        for b in [b'A', b'B', b'C'] {
+            let res = svc.post_mailbox(&id, Body::from(frame(b))).await.expect("post");
+            assert_eq!(res.status(), StatusCode::OK, "each append should be accepted");
+        }
+
+        // A single GET returns every appended frame, concatenated in order.
+        let res = svc.get_mailbox(&id).await.expect("get");
+        assert_eq!(res.status(), StatusCode::OK);
+        let bytes = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(bytes.len(), 3 * FRAME_SIZE, "all three frames returned in one response");
+
+        let expected: Vec<u8> =
+            [b'A', b'B', b'C'].into_iter().flat_map(|b| vec![b; FRAME_SIZE]).collect();
+        assert_eq!(bytes.as_ref(), expected.as_slice(), "frames concatenated in append order");
     }
 
     // V1 routing

--- a/payjoin-mailroom/src/lib.rs
+++ b/payjoin-mailroom/src/lib.rs
@@ -228,9 +228,12 @@ async fn init_directory(
     sentinel_tag: SentinelTag,
     metrics: &MetricsService,
 ) -> anyhow::Result<DirectoryService> {
-    let files_db =
+    let mut files_db =
         crate::db::FilesDb::init(config.timeout, config.storage_dir.clone(), config.mailbox_ttl)
             .await?;
+    if config.append_mailbox {
+        files_db = files_db.with_append_mailbox();
+    }
     files_db.spawn_background_prune().await;
     let db = crate::db::MetricsDb::new(crate::db::DbServiceAdapter::new(files_db), metrics.clone());
 

--- a/payjoin/src/core/append_mailbox.rs
+++ b/payjoin/src/core/append_mailbox.rs
@@ -1,0 +1,248 @@
+//! Client helpers for append-only Payjoin Directory mailboxes.
+//!
+//! A mailbox is addressed by a [`ShortId`] and holds a sequence of fixed-size
+//! HPKE-encrypted frames. [`append_request`] encrypts a message and builds the
+//! request to append it; [`read_request`] reads the whole mailbox and
+//! [`process_read_response`] decrypts the frames addressed to the reader. The
+//! caller supplies the [`ShortId`] and the HPKE keys, and sends each returned
+//! [`Request`] with its own HTTP client.
+
+use crate::directory::{ShortId, PADDED_MESSAGE_BYTES};
+use crate::hpke::{decrypt_message_a, encrypt_message_a, HpkeError};
+use crate::ohttp::{
+    ohttp_encapsulate, process_get_res, process_post_res, DirectoryResponseError,
+    OhttpEncapsulationError,
+};
+use crate::{
+    HpkeKeyPair, HpkePublicKey, IntoUrl, IntoUrlError, OhttpKeys, Request, Url, UrlParseError,
+};
+
+/// Pairs a mailbox request with the state needed to read its response.
+///
+/// Hold it between sending a [`Request`] and processing the response; it is
+/// consumed when the response is processed.
+pub struct MailboxCtx(ohttp::ClientResponse);
+
+/// Build the request that encrypts `message` and appends it to `mailbox`.
+///
+/// `message` is HPKE-sealed to `receiver_key` into one [`PADDED_MESSAGE_BYTES`]
+/// frame; `reply_key` is the sender's public key, carried inside the ciphertext
+/// so the recipient can reply. Returns the [`Request`] to send and the
+/// [`MailboxCtx`] to process its response with.
+pub fn append_request(
+    ohttp_keys: &OhttpKeys,
+    directory: &Url,
+    ohttp_relay: impl IntoUrl,
+    mailbox: &ShortId,
+    message: &[u8],
+    reply_key: &HpkePublicKey,
+    receiver_key: &HpkePublicKey,
+) -> Result<(Request, MailboxCtx), MailboxError> {
+    let frame = encrypt_message_a(message.to_vec(), reply_key, receiver_key)?;
+    let target = mailbox_endpoint(directory, mailbox);
+    let (body, ctx) = ohttp_encapsulate(&ohttp_keys.0, "POST", target.as_str(), Some(&frame))?;
+    let request = Request::new_v2(&relay_url(ohttp_relay, directory)?, &body);
+    Ok((request, MailboxCtx(ctx)))
+}
+
+/// Process the response to an [`append_request`].
+pub fn process_append_response(res: &[u8], ctx: MailboxCtx) -> Result<(), MailboxError> {
+    process_post_res(res, ctx.0).map_err(MailboxError::from)
+}
+
+/// Build the request that reads the entire `mailbox`.
+pub fn read_request(
+    ohttp_keys: &OhttpKeys,
+    directory: &Url,
+    ohttp_relay: impl IntoUrl,
+    mailbox: &ShortId,
+) -> Result<(Request, MailboxCtx), MailboxError> {
+    let target = mailbox_endpoint(directory, mailbox);
+    let (body, ctx) = ohttp_encapsulate(&ohttp_keys.0, "GET", target.as_str(), None)?;
+    let request = Request::new_v2(&relay_url(ohttp_relay, directory)?, &body);
+    Ok((request, MailboxCtx(ctx)))
+}
+
+/// A mailbox frame decrypted by the reader.
+pub struct DecryptedMessage {
+    /// The plaintext message.
+    pub plaintext: Vec<u8>,
+    /// The sender's reply public key, carried in the frame, to reply to them.
+    pub reply_key: HpkePublicKey,
+}
+
+/// Process the response to a [`read_request`] into the messages addressed to the
+/// reader.
+///
+/// Each frame is HPKE-sealed to one recipient, so the whole mailbox is read and
+/// every frame is decrypted with `receiver_keypair`; frames sealed to other
+/// recipients don't open and are skipped. Returns an empty `Vec` if the mailbox
+/// has no messages yet.
+pub fn process_read_response(
+    res: &[u8],
+    ctx: MailboxCtx,
+    receiver_keypair: &HpkeKeyPair,
+) -> Result<Vec<DecryptedMessage>, MailboxError> {
+    let frames = match process_get_res(res, ctx.0)? {
+        Some(blob) => split_frames(&blob)?,
+        None => return Ok(Vec::new()),
+    };
+    Ok(decrypt_frames(&frames, receiver_keypair))
+}
+
+/// Decrypt the frames addressed to `receiver_keypair`, skipping the rest.
+fn decrypt_frames(frames: &[Vec<u8>], receiver_keypair: &HpkeKeyPair) -> Vec<DecryptedMessage> {
+    frames
+        .iter()
+        .filter_map(|frame| decrypt_message_a(frame, receiver_keypair.secret_key()).ok())
+        .map(|(plaintext, reply_key)| DecryptedMessage { plaintext, reply_key })
+        .collect()
+}
+
+/// Split a concatenated mailbox payload into its fixed-size frames.
+///
+/// Every frame is [`PADDED_MESSAGE_BYTES`]; a payload that isn't a whole number
+/// of frames is rejected as truncated rather than yielding a partial frame.
+pub fn split_frames(blob: &[u8]) -> Result<Vec<Vec<u8>>, MailboxError> {
+    if blob.len() % PADDED_MESSAGE_BYTES != 0 {
+        return Err(MailboxError::PartialFrame { len: blob.len() });
+    }
+    Ok(blob.chunks(PADDED_MESSAGE_BYTES).map(<[u8]>::to_vec).collect())
+}
+
+fn mailbox_endpoint(directory: &Url, mailbox: &ShortId) -> Url {
+    let mut url = directory.clone();
+    url.path_segments_mut()
+        .expect("Payjoin Directory URL cannot be a base")
+        .push(&mailbox.to_string());
+    url
+}
+
+/// Relay URL that reveals only the directory's scheme and authority to the relay.
+fn relay_url(ohttp_relay: impl IntoUrl, directory: &Url) -> Result<Url, MailboxError> {
+    let relay_base = ohttp_relay.into_url()?;
+    let directory_base = directory.join("/")?;
+    Ok(relay_base.join(&format!("/{directory_base}"))?)
+}
+
+/// Error from building or processing a mailbox request.
+#[derive(Debug)]
+pub enum MailboxError {
+    /// Failed to OHTTP-encapsulate the request.
+    Encapsulation(OhttpEncapsulationError),
+    /// The directory returned an unexpected or undecodable response.
+    Response(DirectoryResponseError),
+    /// Failed to parse the directory or relay URL.
+    ParseUrl(UrlParseError),
+    /// Failed to interpret the OHTTP relay argument as a URL.
+    IntoUrl(IntoUrlError),
+    /// Failed to HPKE-seal a message into a frame.
+    Hpke(HpkeError),
+    /// The mailbox payload was not a whole number of frames.
+    PartialFrame { len: usize },
+}
+
+impl From<OhttpEncapsulationError> for MailboxError {
+    fn from(e: OhttpEncapsulationError) -> Self { Self::Encapsulation(e) }
+}
+impl From<HpkeError> for MailboxError {
+    fn from(e: HpkeError) -> Self { Self::Hpke(e) }
+}
+impl From<DirectoryResponseError> for MailboxError {
+    fn from(e: DirectoryResponseError) -> Self { Self::Response(e) }
+}
+impl From<UrlParseError> for MailboxError {
+    fn from(e: UrlParseError) -> Self { Self::ParseUrl(e) }
+}
+impl From<IntoUrlError> for MailboxError {
+    fn from(e: IntoUrlError) -> Self { Self::IntoUrl(e) }
+}
+
+impl std::fmt::Display for MailboxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use MailboxError::*;
+        match self {
+            Encapsulation(e) => write!(f, "OHTTP encapsulation error: {e}"),
+            Response(e) => write!(f, "directory response error: {e}"),
+            ParseUrl(e) => write!(f, "URL parse error: {e}"),
+            IntoUrl(e) => write!(f, "invalid relay URL: {e}"),
+            Hpke(e) => write!(f, "HPKE error: {e}"),
+            PartialFrame { len } =>
+                write!(f, "mailbox payload of {len} bytes is not a whole number of frames"),
+        }
+    }
+}
+
+impl std::error::Error for MailboxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use MailboxError::*;
+        match self {
+            Encapsulation(e) => Some(e),
+            Response(e) => Some(e),
+            ParseUrl(e) => Some(e),
+            IntoUrl(e) => Some(e),
+            Hpke(e) => Some(e),
+            PartialFrame { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_frames_splits_on_frame_boundaries() {
+        let blob = vec![0u8; PADDED_MESSAGE_BYTES * 3];
+        let frames = split_frames(&blob).expect("whole frames");
+        assert_eq!(frames.len(), 3);
+        assert!(frames.iter().all(|f| f.len() == PADDED_MESSAGE_BYTES));
+    }
+
+    #[test]
+    fn split_frames_empty_is_no_frames() {
+        assert!(split_frames(&[]).expect("empty is valid").is_empty());
+    }
+
+    #[test]
+    fn split_frames_rejects_partial() {
+        assert!(matches!(
+            split_frames(&[0u8; PADDED_MESSAGE_BYTES + 1]),
+            Err(MailboxError::PartialFrame { len }) if len == PADDED_MESSAGE_BYTES + 1
+        ));
+    }
+
+    #[test]
+    fn mailbox_endpoint_appends_short_id() {
+        let directory = Url::parse("https://payjo.in").expect("valid url");
+        let mailbox = ShortId([0u8; 8]);
+        let endpoint = mailbox_endpoint(&directory, &mailbox);
+        assert!(endpoint.as_str().ends_with(&mailbox.to_string()));
+    }
+
+    #[test]
+    fn decrypt_frames_keeps_only_messages_for_the_reader() {
+        let alice = HpkeKeyPair::gen_keypair();
+        let bob = HpkeKeyPair::gen_keypair();
+        let sender = HpkeKeyPair::gen_keypair();
+
+        // Two frames sealed to alice, one to bob — as append_request builds them.
+        let frames = vec![
+            encrypt_message_a(b"for alice 1".to_vec(), sender.public_key(), alice.public_key())
+                .unwrap(),
+            encrypt_message_a(b"for bob".to_vec(), sender.public_key(), bob.public_key()).unwrap(),
+            encrypt_message_a(b"for alice 2".to_vec(), sender.public_key(), alice.public_key())
+                .unwrap(),
+        ];
+
+        // Alice reads only the two frames sealed to her, in order.
+        let alice_msgs = decrypt_frames(&frames, &alice);
+        let plaintexts: Vec<&[u8]> = alice_msgs.iter().map(|m| m.plaintext.as_slice()).collect();
+        assert_eq!(plaintexts, vec![&b"for alice 1"[..], &b"for alice 2"[..]]);
+        assert!(alice_msgs.iter().all(|m| m.reply_key == *sender.public_key()));
+
+        // Bob reads only his one frame; a stranger reads none.
+        assert_eq!(decrypt_frames(&frames, &bob).len(), 1);
+        assert!(decrypt_frames(&frames, &HpkeKeyPair::gen_keypair()).is_empty());
+    }
+}

--- a/payjoin/src/core/hpke.rs
+++ b/payjoin/src/core/hpke.rs
@@ -12,7 +12,7 @@ use hpke::rand_core::OsRng;
 use hpke::{Deserializable, OpModeR, OpModeS, Serializable};
 use serde::{Deserialize, Serialize};
 
-pub const PADDED_MESSAGE_BYTES: usize = 7168;
+pub use crate::directory::PADDED_MESSAGE_BYTES;
 pub const PADDED_PLAINTEXT_A_LENGTH: usize =
     PADDED_MESSAGE_BYTES - (ELLSWIFT_ENCODING_SIZE + PUBLIC_KEY_SIZE + POLY1305_TAG_SIZE);
 pub const PADDED_PLAINTEXT_B_LENGTH: usize =

--- a/payjoin/src/core/mod.rs
+++ b/payjoin/src/core/mod.rs
@@ -33,11 +33,14 @@ pub(crate) mod hpke;
 #[cfg(feature = "v2")]
 pub mod persist;
 #[cfg(feature = "v2")]
-pub use crate::hpke::{HpkeKeyPair, HpkePublicKey};
+pub use crate::hpke::{HpkeError, HpkeKeyPair, HpkePublicKey};
 #[cfg(feature = "v2")]
 pub(crate) mod ohttp;
 #[cfg(feature = "v2")]
 pub use crate::ohttp::OhttpKeys;
+#[cfg(feature = "v2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v2")))]
+pub mod append_mailbox;
 
 #[cfg(feature = "io")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io")))]

--- a/payjoin/src/core/ohttp.rs
+++ b/payjoin/src/core/ohttp.rs
@@ -82,7 +82,7 @@ impl fmt::Display for DirectoryResponseError {
                 f,
                 "Unexpected response size {}, expected {} bytes",
                 size,
-                crate::directory::ENCAPSULATED_MESSAGE_BYTES
+                crate::directory::ENCAPSULATED_RESPONSE_BYTES
             ),
             UnexpectedStatusCode(status) => write!(f, "Unexpected status code: {status}"),
         }
@@ -128,7 +128,7 @@ fn process_ohttp_res(
     res: &[u8],
     ohttp_context: ohttp::ClientResponse,
 ) -> Result<http::Response<Vec<u8>>, DirectoryResponseError> {
-    let response_array: &[u8; crate::directory::ENCAPSULATED_MESSAGE_BYTES] =
+    let response_array: &[u8; crate::directory::ENCAPSULATED_RESPONSE_BYTES] =
         res.try_into().map_err(|_| DirectoryResponseError::InvalidSize(res.len()))?;
     tracing::trace!("decapsulating directory response");
     let res = ohttp_decapsulate(ohttp_context, response_array)
@@ -139,7 +139,7 @@ fn process_ohttp_res(
 /// decapsulate ohttp, bhttp response and return http response body and status code
 pub(crate) fn ohttp_decapsulate(
     res_ctx: ohttp::ClientResponse,
-    ohttp_body: &[u8; ENCAPSULATED_MESSAGE_BYTES],
+    ohttp_body: &[u8; crate::directory::ENCAPSULATED_RESPONSE_BYTES],
 ) -> Result<http::Response<Vec<u8>>, OhttpEncapsulationError> {
     let bhttp_body = res_ctx.decapsulate(ohttp_body)?;
     let mut r = std::io::Cursor::new(bhttp_body);

--- a/payjoin/src/directory.rs
+++ b/payjoin/src/directory.rs
@@ -1,6 +1,25 @@
 //! Types relevant to the Payjoin Directory as defined in BIP 77.
 
+/// Fixed size, in bytes, of one Payjoin Directory mailbox message frame.
+///
+/// Every v2 message is an HPKE ciphertext padded to this length, so a mailbox
+/// holds a whole number of these frames.
+pub const PADDED_MESSAGE_BYTES: usize = 7168;
+
+/// Maximum number of message frames a single mailbox read response can carry.
+pub const MAX_FRAMES_PER_RESPONSE: usize = 16;
+
+/// Fixed size, in bytes, of an encapsulated OHTTP *request*.
+///
+/// A request carries at most one message frame, so it stays small. OHTTP pads
+/// every request to this single size so the relay can't distinguish them.
 pub const ENCAPSULATED_MESSAGE_BYTES: usize = 8192;
+
+/// Fixed size, in bytes, of an encapsulated OHTTP *response*.
+///
+/// A mailbox read may return many frames, so responses are larger than
+/// requests.
+pub const ENCAPSULATED_RESPONSE_BYTES: usize = (MAX_FRAMES_PER_RESPONSE + 1) * PADDED_MESSAGE_BYTES;
 
 /// A 64-bit identifier used to identify Payjoin Directory entries.
 ///


### PR DESCRIPTION
Including client support


introduce optional append semantics  to the v2 mailbox storage layer behind a FilesDb feature flag (disabled by default to preserve existing BIP77 single-payload behavior). Messages are appended as fixed-size frames and can be read back by index. In-place appends retain the mailbox creation timestamp and do not consume additional mailbox capacity.

Add ranged reads for append-only mailboxes

Wire the append-only mailbox flag through Config so an operator can enable it, and serve frame-addressed reads: a GET with ?index=N returns the Nth fixed-size frame (202 when not yet present). A whole OHTTP response only fits one frame, so readers fetch frames one index at a time. The read path slices frames from the existing payload, so no Db trait change is needed.

Use a constant for the fixed mailbox frame size

Drop unused timestamp from append_frame

Return multiple mailbox frames per GET

Raise `ENCAPSULATED_MESSAGE_BYTES` from 8 KiB to 256 KiB so a single OHTTP response can carry many fixed-size frames (~36) instead of one.

Because the constant now sizes large buffers, heap-allocate the OHTTP encapsulation buffers that were fixed-size stack arrays and would otherwise risk overflowing the worker-thread stack. The encapsulated message is now a Vec<u8>.

Add append-only mailbox client

Centralize the mailbox frame size constant

Move the canonical HPKE-padded length to the directory module and derive mailbox FRAME_SIZE from it. This removes duplicated constants, eliminates a magic number, and ensures directory frame validation matches the HPKE length from a single source of truth.

Size OHTTP responses separately from requests

A request carries one frame, but a mailbox read response may carry many, so padding both to one size either bloats every request or caps reads at one frame.

Add HPKE encryption to mailbox client API

The mailbox client now handles HPKE encryption internally. append_request encrypts messages before appending and process_read_response decrypts frames addressed to the reader. Callers no longer handle raw ciphertexts.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
